### PR TITLE
Updated snippet names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.5
+
+- [Rename form snippets](https://github.com/whatterz/govuk-visual-studio-code-extension/issues/13)
+
 # 1.0.4
 
 - Fix snippets

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ This extension for Visual Studio Code includes snippets to help in the building 
 
 |Name|Shortcut|Notes|
 |-------------------------|-------------------------|---|
-|[Addresses](https://design-system.service.gov.uk/patterns/addresses/)|`govuk-form-address`||
+|[Addresses](https://design-system.service.gov.uk/patterns/addresses/)|`govuk-address`||
 |[Back link](https://design-system.service.gov.uk/components/back-link/)|`govuk-back-link`||
 |[Breadcrumbs](https://design-system.service.gov.uk/components/breadcrumbs/)|`govuk-breadcrumbs`||
 |[Bulleted lists](https://design-system.service.gov.uk/styles/typography/#bulleted-lists)|`govuk-list-bulleted`||
-|[Button](https://design-system.service.gov.uk/components/button/)|`govuk-form-button`||
+|[Button](https://design-system.service.gov.uk/components/button/)|`govuk-button`||
 |[Caption](https://design-system.service.gov.uk/styles/typography/#headings-with-captions)|`govuk-caption`||
-|[Checkboxes](https://design-system.service.gov.uk/components/checkboxes/)|`govuk-form-checkboxes`||
-|Checkbox, radio and select option|`govuk-form-option`|Use in conjunction with the `govuk-form-checkboxes`, `govuk-form-radios` and `govuk-form-select` Nunjucks snippets.|
-|[Dates](https://design-system.service.gov.uk/components/date-input/)|`govuk-form-date`||
+|[Checkboxes](https://design-system.service.gov.uk/components/checkboxes/)|`govuk-checkboxes`||
+|Checkbox, radio and select option|`govuk-option`|Use in conjunction with the `govuk-checkboxes`, `govuk-radios` and `govuk-select` Nunjucks snippets.|
+|[Dates](https://design-system.service.gov.uk/components/date-input/)|`govuk-date`||
 |[Details](https://design-system.service.gov.uk/components/details/)|`govuk-details`||
 |[Error summary](https://design-system.service.gov.uk/components/error-summary/)|`govuk-error-summary`||
-|[Fieldset](https://design-system.service.gov.uk/components/fieldset/)|`govuk-form-fieldset`||
-|[File upload](https://design-system.service.gov.uk/components/file-upload/)|`govuk-form-file`||
+|[Fieldset](https://design-system.service.gov.uk/components/fieldset/)|`govuk-fieldset`||
+|[File upload](https://design-system.service.gov.uk/components/file-upload/)|`govuk-file`||
 |[Font size override](https://design-system.service.gov.uk/styles/typography/#font-size)|`govuk-font-size`||
 |[Font weight override](https://design-system.service.gov.uk/styles/typography/#font-weight)|`govuk-font-weight`||
 |[Footer](https://design-system.service.gov.uk/components/footer/)|`govuk-footer`||
@@ -39,23 +39,23 @@ This extension for Visual Studio Code includes snippets to help in the building 
 |Link item|`govuk-link-item`||
 |[Links](https://design-system.service.gov.uk/styles/typography/#links)|`govuk-link`||
 |[Lists](https://design-system.service.gov.uk/styles/typography/#lists)|`govuk-list`||
-|[National Insurance Number (NINO)](https://design-system.service.gov.uk/patterns/national-insurance-numbers/)|`govuk-form-nino`||
+|[National Insurance Number (NINO)](https://design-system.service.gov.uk/patterns/national-insurance-numbers/)|`govuk-nino`||
 |[Numbered lists](https://design-system.service.gov.uk/styles/typography/#numbered-lists)|`govuk-list-numbered`||
 |[Panels](https://design-system.service.gov.uk/components/panel/)|`govuk-panel`||
 |[Paragraph body text large](https://design-system.service.gov.uk/styles/typography/#lead-paragraph)|`govuk-paragraph-body-lead`||
 |[Paragraph body text small](https://design-system.service.gov.uk/styles/typography/#body-small)|`govuk-paragraph-body-small`||
 |[Paragraph body text](https://design-system.service.gov.uk/styles/typography/#body)|`govuk-paragraph-body`||
 |[Phase banner](https://design-system.service.gov.uk/components/phase-banner/)|`govuk-phase-banner`||
-|[Radios](https://design-system.service.gov.uk/components/radios/)|`govuk-form-radios`||
+|[Radios](https://design-system.service.gov.uk/components/radios/)|`govuk-radios`||
 |[Section break](https://design-system.service.gov.uk/styles/typography/#section-break)|`govuk-section-break`||
-|[Select](https://design-system.service.gov.uk/components/select/)|`govuk-form-select`||
+|[Select](https://design-system.service.gov.uk/components/select/)|`govuk-select`||
 |[Skip link](https://design-system.service.gov.uk/components/skip-link/)|`govuk-skip-link`||
 |[Tables](https://design-system.service.gov.uk/components/table/)|`govuk-table`||
 |[Tabs](https://design-system.service.gov.uk/components/tabs/)|`govuk-tabs`||
 |Tab item HTML|`govuk-tab-item`|Use in conjunction with the `govuk-tabs` snippet. This snippet can be used to encapsulate a tab panel.|
 |[Tags](https://design-system.service.gov.uk/components/tag/)|`govuk-tag`||
-|[Text input](https://design-system.service.gov.uk/components/text-input/)|`govuk-form-input`||
-|[Textarea](https://design-system.service.gov.uk/components/textarea/)|`govuk-form-textarea`||
+|[Text input](https://design-system.service.gov.uk/components/text-input/)|`govuk-input`||
+|[Textarea](https://design-system.service.gov.uk/components/textarea/)|`govuk-textarea`||
 |[Warning text](https://design-system.service.gov.uk/components/warning-text/)|`govuk-warning-text`||
 
 ## Dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-design-system-snippets",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "simonwhatley",
   "displayName": "GOV.UK Design System snippets",
   "description": "GOV.UK Design System snippets for Nunjucks by Simon Whatley",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -121,7 +121,7 @@
 		"description": "Form group – GOV.UK Design System"
 	},
 	"Form fieldset": {
-		"prefix": "govuk-form-fieldset",
+		"prefix": "govuk-fieldset",
 		"body": [
 		"{{ govukFieldset({",
 		"\tlegend: {",
@@ -280,7 +280,7 @@
 		"description": "Numbered lists – GOV.UK Design System"
 	},
 	"Button": {
-		"prefix": "govuk-form-button",
+		"prefix": "govuk-button",
 		"body": [
 			"{{ govukButton({",
 			"\ttext: \"${1:Button text}\"",
@@ -290,7 +290,7 @@
 		"description": "Button – GOV.UK Design System"
 	  },
 	"Checkboxes": {
-		"prefix": "govuk-form-checkboxes",
+		"prefix": "govuk-checkboxes",
 		"body": [
 			"{{ govukCheckboxes({",
 			"\tidPrefix: \"$1\",",
@@ -306,7 +306,7 @@
 			"\t\ttext: \"$5\"",
 			"\t},",
 			"\titems: [",
-			"\t\t${6:Use govuk-form-option snippet}",
+			"\t\t${6:Use govuk-option snippet}",
 			"\t]",
 			"}) }}$7",
 			"$0"
@@ -314,7 +314,7 @@
 		"description": "Checkboxes – GOV.UK Design System"
 	},
 	"Radios": {
-		"prefix": "govuk-form-radios",
+		"prefix": "govuk-radios",
 		"body": [
 			"{{ govukRadios({",
 			"\tidPrefix: \"$1\",",
@@ -330,7 +330,7 @@
 			"\t\ttext: \"$5\"",
 			"\t},",
 			"\titems: [",
-			"\t\t${6:Use govuk-form-option snippet}",
+			"\t\t${6:Use govuk-option snippet}",
 			"\t]",
 			"}) }}$7",
 			"$0"
@@ -338,7 +338,7 @@
 		"description": "Radios – GOV.UK Design System"
 	},
 	"Select": {
-		"prefix": "govuk-form-select",
+		"prefix": "govuk-select",
 		"body": [
 			"{{ govukSelect({",
 			"\tid: \"$1\",",
@@ -347,7 +347,7 @@
 			"\t\ttext: \"${2:Label text}\"",
 			"\t},",
 			"\titems: [",
-			"\t\t${3:Use govuk-form-option snippet}",
+			"\t\t${3:Use govuk-option snippet}",
 			"\t]",
 			"}) }}$4",
 			"$0"
@@ -355,7 +355,7 @@
 		"description": "Select – GOV.UK Design System"
 	},
 	"Radio, checkbox or select option": {
-		"prefix": "govuk-form-option",
+		"prefix": "govuk-option",
 		"body": [
 			"{",
 				"value: \"$1\",",
@@ -366,7 +366,7 @@
 		"description": "Radio, checkbox or select option – GOV.UK Design System"
 	},
 	"Text input": {
-		"prefix": "govuk-form-input",
+		"prefix": "govuk-input",
 		"body": [
 			"{{ govukInput({",
 			"\tid: \"$1\",",
@@ -383,7 +383,7 @@
 		"description": "Text input – GOV.UK Design System"
 	},
 	"Textarea": {
-		"prefix": "govuk-form-textarea",
+		"prefix": "govuk-textarea",
 		"body": [
 			"{{ govukTextarea({",
 			"\tid: \"$1\",",
@@ -400,7 +400,7 @@
 		"description": "Textarea – GOV.UK Design System"
 	},
 	"Address": {
-		"prefix": "govuk-form-address",
+		"prefix": "govuk-address",
 		"body": [
 			"{% call govukFieldset({",
 			"\tlegend: {",
@@ -459,7 +459,7 @@
 		"description": "Addresses – GOV.UK Design System"
 	},
 	"Date input": {
-		"prefix": "govuk-form-date",
+		"prefix": "govuk-date",
 		"body": [
 			"{{ govukDateInput({",
 			"\tid: \"${1:date}\",",
@@ -491,7 +491,7 @@
 		"description": "Date input – GOV.UK Design System"
 	},
 	"File upload": {
-		"prefix": "govuk-form-file",
+		"prefix": "govuk-file",
 		"body": [
 			"{{ govukFileUpload({",
 			"\tid: \"${1:file-upload-1}\",",
@@ -505,7 +505,7 @@
 		"description": "File upload – GOV.UK Design System"
 	},
 	"National Insurance number (NINO)": {
-		"prefix": "govuk-form-nino",
+		"prefix": "govuk-nino",
 		"body": [
 			"{{ govukInput({",
 			"\tid: \"national-insurance-number\",",


### PR DESCRIPTION
Fixes #13 Rename snippets, removing `form-` from the snippet name:

- govuk-address
- govuk-button
- govuk-checkboxes
- govuk-date
- govuk-fieldset
- govuk-file
- govuk-input
- govuk-nino
- govuk-radios
- govuk-select
- govuk-textarea